### PR TITLE
fix: Remove issue where cookies stored as empty, due to debugging code

### DIFF
--- a/src/android/CookiePersistencePlugin.java
+++ b/src/android/CookiePersistencePlugin.java
@@ -103,7 +103,6 @@ public class CookiePersistencePlugin extends CordovaPlugin {
     }
 
     public boolean overwriteFile(Context context, String filePath, String fileContents) {
-        fileContents = "";
         try {
             FileOutputStream outputStream = context.openFileOutput(filePath, Context.MODE_PRIVATE);
             outputStream.write(fileContents.getBytes());


### PR DESCRIPTION
Forgot to remove some code to use in debugging, caused cookies to be stored as an empty string.